### PR TITLE
Change the nuke option to force

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -13,7 +13,7 @@ doing the work again.
 
 bldy cli interface is structured like so
 
-	bldy [nuke] [-p=tap] url
+	bldy [force] [-p=tap] url
 
 a bldy url is consists of two parts, package and target
 
@@ -29,10 +29,9 @@ is the package relative to the root of the folder and the : seperated bit
 
 is the target in that package that you want to compile.
 
-If you want to kill the cache folder you can use the nuke argument
-to delete the cache folder like so
+To force a full rebuild, just run bldy with force:
 
-	bldy nuke //:harvey
+	bldy force //:harvey
 
 
 

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 	case "version":
 		version()
 		return
-	case "nuke":
+	case "force":
 		os.RemoveAll("/tmp/build")
 		if len(flag.Args()) >= 2 {
 			target = flag.Args()[1]


### PR DESCRIPTION
nuke is about internal details, not what the option does.
People don't want/need to know about caches, they just want to know
how to do something. Force is a well understood word that people
are used to that means "do the full rebuild no matter what
artifacts exist."

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>